### PR TITLE
Fix all the 'Warning: Interpolation-only expressions are deprecated' …

### DIFF
--- a/calico.tf
+++ b/calico.tf
@@ -1,7 +1,7 @@
 resource "null_resource" "setup_calico" {
   connection {
     user = "root"
-    host = "${packet_device.k8s_controller.access_public_ipv4}"
+    host = packet_device.k8s_controller.access_public_ipv4
   }
 
   provisioner "file" {
@@ -15,5 +15,5 @@ resource "null_resource" "setup_calico" {
     ]
   }
 
-  depends_on = ["packet_device.k8s_controller"]
+  depends_on = [packet_device.k8s_controller]
 }

--- a/controller.tf
+++ b/controller.tf
@@ -4,17 +4,17 @@ variable "hostname" {
 
 // Setup the kubernetes controller node
 resource "packet_device" "k8s_controller" {
-  project_id       = "${packet_project.kubenet.id}"
-  facilities       = "${var.facilities}"
-  plan             = "${var.controller_plan}"
+  project_id       = packet_project.kubenet.id
+  facilities       = var.facilities
+  plan             = var.controller_plan
   operating_system = "ubuntu_16_04"
-  hostname         = "${format("%s-%s", "${var.facilities[0]}", "${var.hostname}")}"
+  hostname         = format("%s-%s", var.facilities[0], var.hostname)
   billing_cycle    = "hourly"
   tags             = ["kubernetes", "k8s", "controller"]
 
   connection {
     user = "root"
-    host = "${packet_device.k8s_controller.access_public_ipv4}"
+    host = packet_device.k8s_controller.access_public_ipv4
   }
 
   provisioner "file" {
@@ -23,17 +23,17 @@ resource "packet_device" "k8s_controller" {
   }
 
   provisioner "file" {
-    content     = "${data.template_file.install_docker.rendered}"
+    content     = data.template_file.install_docker.rendered
     destination = "/tmp/install-docker.sh"
   }
 
   provisioner "file" {
-    content     = "${data.template_file.install_kubernetes.rendered}"
+    content     = data.template_file.install_kubernetes.rendered
     destination = "/tmp/setup-kube.sh"
   }
 
   provisioner "file" {
-    content     = "${data.template_file.setup_kubeadm.rendered}"
+    content     = data.template_file.setup_kubeadm.rendered
     destination = "/tmp/setup-kubeadm.sh"
   }
 
@@ -58,15 +58,15 @@ data "external" "kubeadm_join" {
   program = ["./scripts/kubeadm-token.sh"]
 
   query = {
-    host = "${packet_device.k8s_controller.access_public_ipv4}"
+    host = packet_device.k8s_controller.access_public_ipv4
   }
 
   # Make sure to only run this after the controller is up and setup
-  depends_on = ["packet_device.k8s_controller"]
+  depends_on = [packet_device.k8s_controller]
 }
 
 data "template_file" "setup_kubeadm" {
-  template = "${file("${path.module}/templates/setup-kubeadm.sh.tpl")}"
+  template = file("${path.module}/templates/setup-kubeadm.sh.tpl")
 
   vars = {
     kubernetes_version      = "v${var.kubernetes_version}"

--- a/controller.tf
+++ b/controller.tf
@@ -7,7 +7,7 @@ resource "packet_device" "k8s_controller" {
   project_id       = packet_project.kubenet.id
   facilities       = var.facilities
   plan             = var.controller_plan
-  operating_system = "ubuntu_16_04"
+  operating_system = "ubuntu_18_04"
   hostname         = format("%s-%s", var.facilities[0], var.hostname)
   billing_cycle    = "hourly"
   tags             = ["kubernetes", "k8s", "controller"]

--- a/istio.tf
+++ b/istio.tf
@@ -1,0 +1,20 @@
+resource "null_resource" "setup_istio" {
+  connection {
+    user = "root"
+    host = packet_device.k8s_controller.access_public_ipv4
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/install-istio.sh"
+    destination = "/tmp/install-istio.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/*.sh",
+      "/tmp/install-istio.sh",
+    ]
+  }
+
+  depends_on = [packet_device.k8s_controller]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "packet" {
-  auth_token = "${var.auth_token}"
+  auth_token = var.auth_token
 }
 
 resource "packet_project" "kubenet" {
@@ -34,7 +34,7 @@ data "template_file" "install_docker" {
   template = "${file("${path.module}/templates/install-docker.sh.tpl")}"
 
   vars = {
-    docker_version = "${var.docker_version}"
+    docker_version = var.docker_version
   }
 }
 
@@ -42,6 +42,6 @@ data "template_file" "install_kubernetes" {
   template = "${file("${path.module}/templates/setup-kube.sh.tpl")}"
 
   vars = {
-    kubernetes_version = "${var.kubernetes_version}"
+    kubernetes_version = var.kubernetes_version
   }
 }

--- a/nodes.tf
+++ b/nodes.tf
@@ -62,6 +62,15 @@ resource "null_resource" "setup_worker" {
       host = packet_device.k8s_controller.access_public_ipv4
     }
   }
+
+  # add felix dikastest container connectivity
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds",
+      "docker run --rm -v /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds:/host/driver calico/pod2daemon-flexvol:v3.8.0",
+    ]
+  }
+
 }
 
 # We need to get the private IPv4 Gateway of each worker

--- a/nodes.tf
+++ b/nodes.tf
@@ -3,7 +3,7 @@ resource "packet_device" "k8s_workers" {
   facilities       = var.facilities
   count            = var.worker_count
   plan             = var.worker_plan
-  operating_system = "ubuntu_16_04"
+  operating_system = "ubuntu_18_04"
   hostname         = format("%s-%s-%d", "${var.facilities[0]}", "worker", count.index)
   billing_cycle    = "hourly"
   tags             = ["kubernetes", "k8s", "worker"]

--- a/nodes.tf
+++ b/nodes.tf
@@ -1,21 +1,21 @@
 resource "packet_device" "k8s_workers" {
-  project_id       = "${packet_project.kubenet.id}"
-  facilities       = "${var.facilities}"
-  count            = "${var.worker_count}"
-  plan             = "${var.worker_plan}"
+  project_id       = packet_project.kubenet.id
+  facilities       = var.facilities
+  count            = var.worker_count
+  plan             = var.worker_plan
   operating_system = "ubuntu_16_04"
-  hostname         = "${format("%s-%s-%d", "${var.facilities[0]}", "worker", count.index)}"
+  hostname         = format("%s-%s-%d", "${var.facilities[0]}", "worker", count.index)
   billing_cycle    = "hourly"
   tags             = ["kubernetes", "k8s", "worker"]
 }
 
 # Using a null_resource so the packet_device doesn't not have to wait to be initially provisioned
 resource "null_resource" "setup_worker" {
-  count = "${var.worker_count}"
+  count = var.worker_count
 
   connection {
     user = "root"
-    host = "${element(packet_device.k8s_workers.*.access_public_ipv4, count.index)}"
+    host = element(packet_device.k8s_workers.*.access_public_ipv4, count.index)
   }
 
   provisioner "file" {
@@ -24,12 +24,12 @@ resource "null_resource" "setup_worker" {
   }
 
   provisioner "file" {
-    content     = "${data.template_file.install_docker.rendered}"
+    content     = data.template_file.install_docker.rendered
     destination = "/tmp/install-docker.sh"
   }
 
   provisioner "file" {
-    content     = "${data.template_file.install_kubernetes.rendered}"
+    content     = data.template_file.install_kubernetes.rendered
     destination = "/tmp/setup-kube.sh"
   }
 
@@ -44,7 +44,7 @@ resource "null_resource" "setup_worker" {
       "/tmp/setup-base.sh",
       "/tmp/install-docker.sh",
       "/tmp/setup-kube.sh",
-      "${data.external.kubeadm_join.result.command}",
+      data.external.kubeadm_join.result.command,
       "/tmp/install-calicoctl.sh",
     ]
   }
@@ -54,19 +54,19 @@ resource "null_resource" "setup_worker" {
       "kubectl get nodes -o wide",
     ]
 
-    on_failure = "continue"
+    on_failure = continue
 
     connection {
       type = "ssh"
       user = "root"
-      host = "${packet_device.k8s_controller.access_public_ipv4}"
+      host = packet_device.k8s_controller.access_public_ipv4
     }
   }
 }
 
 # We need to get the private IPv4 Gateway of each worker
 data "external" "private_ipv4_gateway" {
-  count   = "${var.worker_count}"
+  count   = var.worker_count
   program = ["${path.module}/scripts/gateway.sh"]
 
   query = {

--- a/output.tf
+++ b/output.tf
@@ -1,15 +1,15 @@
 output "master_address" {
-  value = ["${packet_device.k8s_controller.access_public_ipv4}"]
+  value = [packet_device.k8s_controller.access_public_ipv4]
 }
 
 output "kubeadm_join_command" {
-  value = ["${data.external.kubeadm_join.result["command"]}"]
+  value = [data.external.kubeadm_join.result["command"]]
 }
 
 output "worker_addresses" {
-  value = ["${packet_device.k8s_workers.*.access_public_ipv4}"]
+  value = [packet_device.k8s_workers.*.access_public_ipv4]
 }
 
 output "load_balancer_ips" {
-  value = ["${packet_reserved_ip_block.load_balancer_ips.cidr_notation}"]
+  value = [packet_reserved_ip_block.load_balancer_ips.cidr_notation]
 }

--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# source: https://docs.projectcalico.org/v3.11/getting-started/kubernetes/hardway/istio-integration#installing-istio
+
+set -x
+
+export CALICO_DATASTORE_TYPE=kubernetes
+export CALICO_KUBECONFIG=/root/.kube/config
+calicoctl get felixconfiguration default --export -o yaml | \
+sed -e '/  policySyncPathPrefix:/d' \
+    -e '$ a\  policySyncPathPrefix: /var/run/nodeagent' > felix-config.yaml
+calicoctl apply -f felix-config.yaml
+
+cd /root
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.4.2 sh -
+cd $(ls -d istio-*)
+cp bin/istioctl /usr/local/sbin/
+kubectl apply -f install/kubernetes/helm/istio-init/files/
+
+# REMOVE
+kubectl apply -f install/kubernetes/istio-demo.yaml
+kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+kubectl apply -f samples/bookinfo/networking/bookinfo-gateway.yaml
+kubectl apply -f samples/bookinfo/networking/destination-rule-all.yaml
+#/ REMOVE
+
+kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/alp/istio-inject-configmap-1.1.7.yaml
+kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/alp/istio-app-layer-policy.yaml
+kubectl label namespace default istio-injection=enabled

--- a/templates/install-docker.sh.tpl
+++ b/templates/install-docker.sh.tpl
@@ -5,6 +5,8 @@ echo "[----- Begin install-docker.sh ----]"
 
 echo "Installing Docker ${docker_version}"
 
+echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections
+
 # Based on from https://kubernetes.io/docs/setup/cri/#docker
 
 # Install Docker CE

--- a/templates/setup-kube.sh.tpl
+++ b/templates/setup-kube.sh.tpl
@@ -31,4 +31,6 @@ apt-get install -y \
 # Make the kubelet use only the private IP to run it's management controller pods
 echo "KUBELET_EXTRA_ARGS=\"--node-ip=$LOCAL_IP --address=$LOCAL_IP\"" > /etc/default/kubelet
 
+# enable autocompletion for kubectl
+echo "source <(kubectl completion bash)" >> ~/.bashrc
 echo "[---- Done setting up kubernetes configurations -----]"

--- a/templates/setup-kube.sh.tpl
+++ b/templates/setup-kube.sh.tpl
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections
+
 HOSTNAME=$(hostname -s)
 # Get Packet server's private IP address
 LOCAL_IP=$(ip a | grep "inet 10" | cut -d" " -f6 | cut -d"/" -f1)
@@ -16,7 +18,8 @@ apt-get update
 apt-get install -y apt-transport-https curl
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
-deb http://apt.kubernetes.io/ kubernetes-$(lsb_release -cs) main
+# deb http://apt.kubernetes.io/ kubernetes-$(lsb_release -cs) main
+deb http://apt.kubernetes.io/ kubernetes-xenial main # bionic repo doesnt exist yet
 EOF
 apt-get update
 apt-get install -y \


### PR DESCRIPTION
Output using Terraform 0.12 is one endless stream of the following

> Warning: Interpolation-only expressions are deprecated
> 
>   on controller.tf line 11, in resource "packet_device" "k8s_controller":
>   11:   hostname         = "${format("%s-%s", var.facilities[0], var.hostname)}"
> 
> Terraform 0.11 and earlier required all non-constant expressions to be
> provided via interpolation syntax, but this pattern is now deprecated. To
> silence this warning, remove the "${ sequence from the start and the }"
> sequence from the end of this expression, leaving just the inner expression.
> 
> Template interpolation syntax is still used to construct strings from
> expressions when the template includes multiple interpolation sequences or a
> mixture of literal strings and interpolations. This deprecation applies only
> to templates that consist entirely of a single interpolation sequence.

This commit should fix that :)