### PR TITLE
Utilize Packet API to create calico BGPPeers

### DIFF
--- a/controller.tf
+++ b/controller.tf
@@ -7,7 +7,7 @@ resource "packet_device" "k8s_controller" {
   project_id       = packet_project.kubenet.id
   facilities       = var.facilities
   plan             = var.controller_plan
-  operating_system = "ubuntu_16_04"
+  operating_system = "ubuntu_20_04"
   hostname         = format("%s-%s", var.facilities[0], var.hostname)
   billing_cycle    = "hourly"
   tags             = ["kubernetes", "k8s", "controller"]

--- a/metallb.tf
+++ b/metallb.tf
@@ -80,7 +80,7 @@ resource "null_resource" "calico_node_peers" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/calico/bgppeer-${count.index}.sh",
-      "/tmp/calico/bgppeer-${count.index}.sh ${element(packet_device.k8s_workers.*.hostname, count.index)} ${element(data.external.private_ipv4_gateway.*.result.peer_ip, count.index)}",
+      "/tmp/calico/bgppeer-${count.index}.sh ${var.auth_token} ${element(packet_device.k8s_workers.*.id, count.index)} ${element(packet_device.k8s_workers.*.hostname, count.index)}",
     ]
   }
 

--- a/nodes.tf
+++ b/nodes.tf
@@ -3,7 +3,7 @@ resource "packet_device" "k8s_workers" {
   facilities       = var.facilities
   count            = var.worker_count
   plan             = var.worker_plan
-  operating_system = "ubuntu_16_04"
+  operating_system = "ubuntu_20_04"
   hostname         = format("%s-%s-%d", var.facilities[0], "worker", count.index)
   billing_cycle    = "hourly"
   tags             = ["kubernetes", "k8s", "worker"]

--- a/nodes.tf
+++ b/nodes.tf
@@ -55,6 +55,7 @@ resource "null_resource" "setup_worker" {
       "/tmp/install-calicoctl.sh",
 
 # Only enable the execution of this next line if you see issues with BGP peering
+# Some BGP speakers will not respect source routing so adding static routes can help.
 #      "/tmp/bgp-routes.sh",
     ]
   }

--- a/nodes.tf
+++ b/nodes.tf
@@ -40,6 +40,11 @@ resource "null_resource" "setup_worker" {
     destination = "/tmp/install-calicoctl.sh"
   }
 
+  provisioner "file" {
+    source      = "${path.module}/scripts/bgp-routes.sh"
+    destination = "/tmp/bgp-routes.sh"
+  }
+  
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/*.sh",
@@ -48,6 +53,9 @@ resource "null_resource" "setup_worker" {
       "/tmp/setup-kube.sh",
       "${data.external.kubeadm_join.result.command}",
       "/tmp/install-calicoctl.sh",
+
+# Only enable the execution of this next line if you see issues with BGP peering
+#      "/tmp/bgp-routes.sh",
     ]
   }
 

--- a/scripts/bgp-routes.sh
+++ b/scripts/bgp-routes.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -x
+
+GATEWAY_PRIVATE_IPV4=($(curl https://metadata.packet.net/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway"))
+
+
+PEER_IPS_AMOUNT=($(curl https://metadata.packet.net/metadata | jq ".bgp_neighbors[].peer_ips | length"))
+
+i="0"
+
+while [ $i -lt $PEER_IPS_AMOUNT ]
+do
+
+PEER_IP=$(curl https://metadata.packet.net/metadata | jq -r ".bgp_neighbors[].peer_ips[$i]")
+
+ip route add $PEER_IP via $GATEWAY_PRIVATE_IPV4 dev bond0
+
+
+i=$[$i+1]
+
+done

--- a/scripts/calico-bgppeer.sh
+++ b/scripts/calico-bgppeer.sh
@@ -2,16 +2,27 @@
 
 set -x
 
-HOSTNAME=$1
-PEER_IP=$2
+API_KEY=$1
+INSTANCE_UUID=$2
+HOSTNAME=$3
+PEER_IPS_AMOUNT=($(curl -X GET -H "X-Auth-Token: ${API_KEY}" "https://api.packet.net/devices/${INSTANCE_UUID}/bgp/neighbors" | jq ".bgp_neighbors[].peer_ips | length"))
+
+i="0"
+
+while [ $i -lt $PEER_IPS_AMOUNT ]
+do
 
 cat << EOF | DATASTORE_TYPE=kubernetes KUBECONFIG=~/.kube/config calicoctl create -f -
 apiVersion: projectcalico.org/v3
 kind: BGPPeer
 metadata:
-  name: $HOSTNAME
+  name: $HOSTNAME-peer-$i
 spec:
-  peerIP: $PEER_IP
-  node: $HOSTNAME
+  peerIP: $(curl -X GET -H "X-Auth-Token: ${API_KEY}" "https://api.packet.net/devices/${INSTANCE_UUID}/bgp/neighbors" | jq -r ".bgp_neighbors[].peer_ips[$i]")
+  node: $HOSTNAME-peer-$i
   asNumber: 65530
 EOF
+
+i=$[$i+1]
+
+done

--- a/scripts/calico-bgppeer.sh
+++ b/scripts/calico-bgppeer.sh
@@ -19,7 +19,7 @@ metadata:
   name: $HOSTNAME-peer-$i
 spec:
   peerIP: $(curl -X GET -H "X-Auth-Token: ${API_KEY}" "https://api.packet.net/devices/${INSTANCE_UUID}/bgp/neighbors" | jq -r ".bgp_neighbors[].peer_ips[$i]")
-  node: $HOSTNAME-peer-$i
+  node: $HOSTNAME
   asNumber: 65530
 EOF
 

--- a/templates/install-docker.sh.tpl
+++ b/templates/install-docker.sh.tpl
@@ -5,6 +5,8 @@ echo "[----- Begin install-docker.sh ----]"
 
 echo "Installing Docker ${docker_version}"
 
+echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections
+
 # Based on from https://kubernetes.io/docs/setup/cri/#docker
 
 # Install Docker CE

--- a/templates/setup-kube.sh.tpl
+++ b/templates/setup-kube.sh.tpl
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections
+
 HOSTNAME=$(hostname -s)
 # Get Packet server's private IP address
 LOCAL_IP=$(ip a | grep "inet 10" | cut -d" " -f6 | cut -d"/" -f1)
@@ -16,7 +18,9 @@ apt-get update
 apt-get install -y apt-transport-https curl
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
-deb http://apt.kubernetes.io/ kubernetes-$(lsb_release -cs) main
+#deb http://apt.kubernetes.io/ kubernetes-$(lsb_release -cs) main
+# bionic (18.04) or focal (20.04) repo for ubuntu dont exist yet
+deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
 apt-get install -y \


### PR DESCRIPTION
This update changes the way that calico bgppeers were being created by utilizing the /devices API endpoint to retrieve bgp neighbor info. This update is necessary for new locations with newer networking equipment such as NY5.